### PR TITLE
`Chore`: Add development setup explanation to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 Use `docker compose up` for quick start.
+
+## Development
+
+### Running [Artemis](https://github.com/ls1intum/Artemis) in parallel (locally)
+Adjust the port on which the telemetry service and its database are running (with the default configuration Artemis will be running on port 8080 and a mysql database on port 3306).
+
+Adjust the `docker-compose.yml` accordingly, e.g. the following adjustments will be needed to run the telemetry service on port `8081` and its database on port `3307`:  
+```
+services:
+telemetry:
+  ports:
+    - '127.0.0.1:8081:8080'
+mysql:
+  ports:
+    - "3307:3306"
+```
+
+For using the local telemetry service in a development setup you will need to adjust the `application-dev.yml` (within Artemis, not within the telemetry service) accordingly:
+```
+artemis:
+  telemetry:
+    enabled: true
+    sendAdminDetails: true
+    destination: http://localhost:8081
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Use `docker compose up` for quick start.
 ## Development
 
 ### Running [Artemis](https://github.com/ls1intum/Artemis) in parallel (locally)
-Adjust the port on which the telemetry service and its database are running (with the default configuration Artemis will be running on port 8080 and a mysql database on port 3306).
+Adjust the port on which the telemetry service and its database are running (with the default configuration Artemis will be running on port `8080` and a mysql database on port `3306`).
 
 Adjust the `docker-compose.yml` accordingly, e.g. the following adjustments will be needed to run the telemetry service on port `8081` and its database on port `3307`:  
 ```


### PR DESCRIPTION
Adds a description for developers to setup the telemetry service and Artemis on the same machine.
Mainly intended to make it easier to test PRs related to this repository in the future, as the setup is explained in the ReadMe and does not need to be explained in the PRs (in the Artemis Repository) anymore.